### PR TITLE
add phpldapadmin to allow LDAP server manipulation and show user admin

### DIFF
--- a/ldap/add-user
+++ b/ldap/add-user
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Creating the users
+docker-compose exec kafka kafka-configs --zookeeper zookeeper:2181 --alter --add-config 'SCRAM-SHA-256=[password=purbon-secret],SCRAM-SHA-512=[password=purbon-secret]' --entity-type users --entity-name purbon
+
+
+echo "Should succeed as the new user is in the group"
+echo "-> docker-compose exec kafka kafka-console-producer --broker-list kafka:9093 --topic test-topic --producer.config=/service/kafka/users/purbon.properties"
+echo "-> docker-compose exec kafka kafka-console-consumer --bootstrap-server kafka:9093 --consumer.config /service/kafka/users/purbon.properties --topic test-topic --from-beginning"

--- a/ldap/docker-compose.yaml
+++ b/ldap/docker-compose.yaml
@@ -14,6 +14,16 @@ services:
             - "$PWD/ldap/custom:/container/service/slapd/assets/config/bootstrap/ldif/custom"
         command: "--copy-service"
 
+    phpldapadmin-service:
+        image: osixia/phpldapadmin:0.7.2
+        container_name: ldapadmin-service
+        environment:
+          - PHPLDAPADMIN_LDAP_HOSTS=ldap
+        ports:
+          - "6443:443"
+        depends_on:
+          - ldap
+
     zookeeper:
         build: zookeeper/
         hostname: zookeeper
@@ -30,6 +40,7 @@ services:
             - zookeeper
             - ldap
         volumes:
+            - "$PWD/kafka/users:/service/kafka/users"
             - "$PWD/kafka/jks:/etc/kafka/jks"
         ports:
             - "9093:9093"

--- a/ldap/kafka/server.properties
+++ b/ldap/kafka/server.properties
@@ -22,7 +22,7 @@ broker.id=0
 
 ############################# Socket Server Settings #############################
 
-# The address the socket server listens on. It will get the value returned from 
+# The address the socket server listens on. It will get the value returned from
 # java.net.InetAddress.getCanonicalHostName() if not configured.
 #   FORMAT:
 #     listeners = listener_name://host_name:port
@@ -30,7 +30,7 @@ broker.id=0
 #     listeners = PLAINTEXT://your.host.name:9092
 listeners=SASL_PLAINTEXT://kafka:9093
 
-# Hostname and port the broker will advertise to producers and consumers. If not set, 
+# Hostname and port the broker will advertise to producers and consumers. If not set,
 # it uses the value for "listeners" if configured.  Otherwise, it will use the value
 # returned from java.net.InetAddress.getCanonicalHostName().
 advertised.listeners=SASL_PLAINTEXT://kafka:9093
@@ -140,7 +140,7 @@ zookeeper.connection.timeout.ms=6000
 # Uncomment the following line if the metrics cluster has a single broker
 #confluent.metrics.reporter.topic.replicas=1
 
-##################### Confluent Proactive Support ###################### 
+##################### Confluent Proactive Support ######################
 # If set to true, and confluent-support-metrics package is installed
 # then the feature to collect and report support metrics
 # ("Metrics") is enabled.  If set to false, the feature is disabled.
@@ -185,9 +185,11 @@ authorizer.class.name=io.confluent.kafka.security.ldap.authorizer.LdapAuthorizer
 # LDAP provider URL
 ldap.authorizer.java.naming.provider.url=ldap://ldap:389/DC=CONFLUENT,DC=IO
 # Refresh interval for LDAP cache. If set to zero, persistent search is used.
-ldap.authorizer.refresh.interval.ms=60000
-# Lets try to see if we can run without security
+# Reduced this value from the default 60000ms (60sec) to 10sec to detect
+# faster the updates done in the LDAP database
+ldap.authorizer.refresh.interval.ms=10000
 
+# Lets try to see if we can run without security
 ldap.authorizer.java.naming.security.authentication=SIMPLE
 ldap.authorizer.java.naming.security.principal=cn=admin,dc=confluent,dc=io
 ldap.authorizer.java.naming.security.credentials=admin
@@ -210,4 +212,3 @@ ldap.authorizer.group.name.attribute.pattern=
 ldap.authorizer.group.member.attribute=memberUid
 # Regex pattern to obtain user principal from group member attribute
 ldap.authorizer.group.member.attribute.pattern=cn=(.*),ou=users,dc=confluent,dc=io
-

--- a/ldap/kafka/users/purbon.properties
+++ b/ldap/kafka/users/purbon.properties
@@ -1,0 +1,5 @@
+sasl.mechanism=SCRAM-SHA-256
+security.protocol=SASL_PLAINTEXT
+sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required \
+  username="purbon" \
+  password="purbon-secret";


### PR DESCRIPTION
This PR adds two interesting bits:

+ phpldapadmin to allow a visual LDAP user admin (CRUD)
+ Add an script to add a new user

with this two blocks, we can show how the operation of the LDAP connection could looks like.

Looking forward to know what do you think,

@Dabz @sknop  