### PR TITLE
SCRAM auth cleanup

### DIFF
--- a/scram/kafka/kafka.sasl.jaas.config
+++ b/scram/kafka/kafka.sasl.jaas.config
@@ -5,6 +5,6 @@ KafkaServer {
 };
 Client {
    org.apache.zookeeper.server.auth.DigestLoginModule required
-   username="kafka"
-   password="kafka";
+   username="admin"
+   password="password";
 };

--- a/scram/kafka/server.properties
+++ b/scram/kafka/server.properties
@@ -38,7 +38,6 @@ advertised.listeners=SASL_PLAINTEXT://kafka:9093
 # Maps listener names to security protocols, the default is for them to be the same. See the config documentation for more details
 #listener.security.protocol.map=PLAINTEXT:PLAINTEXT,SSL:SSL,SASL_PLAINTEXT:SASL_PLAINTEXT,SASL_SSL:SASL_SSL
 
-security.inter.broker.protocol=SASL_PLAINTEXT
 
 # The number of threads that the server uses for receiving requests from the network and sending responses to the network
 num.network.threads=3
@@ -179,3 +178,4 @@ security.inter.broker.protocol=SASL_PLAINTEXT
 allow.everyone.if.no.acl.found=false
 super.users=User:kafka
 authorizer.class.name=kafka.security.auth.SimpleAclAuthorizer
+zookeeper.set.acl=true

--- a/scram/zookeeper/zookeeper.properties
+++ b/scram/zookeeper/zookeeper.properties
@@ -19,4 +19,3 @@ clientPort=2181
 # disable the per-ip limit on the number of connections since this is a non-production config
 maxClientCnxns=0
 authProvider.1 = org.apache.zookeeper.server.auth.SASLAuthenticationProvider
-requireClientAuthScheme=sasl

--- a/scram/zookeeper/zookeeper.sasl.jaas.config
+++ b/scram/zookeeper/zookeeper.sasl.jaas.config
@@ -1,4 +1,4 @@
 Server {
    org.apache.zookeeper.server.auth.DigestLoginModule required
-   user_kafka="kafka";
+   user_admin="password";
 };


### PR DESCRIPTION
changed Kafka ZK user to be different from inter-broker auth user to avoid confusion in the logs
removed duplicate security.inter.broker.protocol from broker config
enable broker to set ACLs on znodes it creates
removed requireClientAuthScheme=sasl from ZK as it does nothing