### PR TITLE
[Playbook] How to use Apache Kafka 2.4 (upcoming trunk) Zookeeper 3.5.5 with a TLS connection

### DIFF
--- a/apache-kafka-with-zk3.5-and-tls/.gitignore
+++ b/apache-kafka-with-zk3.5-and-tls/.gitignore
@@ -1,0 +1,6 @@
+bin/
+certs/
+certs-old/
+tmp-dir
+images/
+zookeeper.properties

--- a/apache-kafka-with-zk3.5-and-tls/README.md
+++ b/apache-kafka-with-zk3.5-and-tls/README.md
@@ -5,6 +5,13 @@ Apache Zookeeper counter part.
 
 As of today, this only covers using Zookeeper 3.5.5 with the upcoming Apache Kafka 2.4 version. Using it in earlier versions is not properly tested.
 
+## Run the playbook.
+
+To run the playbook you need installed in your machine, docker, docker-compose.
+
+The playbook can be started by running the _$> ./up_ script.
+
+
 ### Configuration on Apache ZooKeeper
 
 Required environment variables:

--- a/apache-kafka-with-zk3.5-and-tls/README.md
+++ b/apache-kafka-with-zk3.5-and-tls/README.md
@@ -1,0 +1,57 @@
+# Apache Kafka 2.4 (trunk) with Zookeeper 3.5.5
+
+This playbook show the current (as of August 2019) necessary steps to enable a secured TLS connection between an Apache Kafka broker and his corresponding
+Apache Zookeeper counter part.
+
+As of today, this only covers using Zookeeper 3.5.5 with the upcoming Apache Kafka 2.4 version. Using it in earlier versions is not properly tested.
+
+### Configuration on Apache ZooKeeper
+
+Required environment variables:
+
+```bash
+SERVER_JVMFLAGS=-Dzookeeper.serverCnxnFactory=org.apache.zookeeper.server.NettyServerCnxnFactory
+````
+
+zoo.cfg file:
+
+```bash
+secureClientPort=2182
+authProvider.1=org.apache.zookeeper.server.auth.X509AuthenticationProvider
+ssl.trustStore.location=/var/lib/secret/truststore.jks
+ssl.trustStore.password=test1234
+ssl.keyStore.location=/var/lib/secret/zookeeper.jks
+ssl.keyStore.password=test1234
+ssl.clientAuth=true
+```
+
+### Configuration for Apache Kafka
+
+Required environment variables:
+
+```bash
+KAFKA_OPTS=-Dzookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty -Dzookeeper.client.secure=true -Dzookeeper.ssl.keyStore.location=/var/lib/secret/kafka.jks -Dzookeeper.ssl.keyStore.password=confluent -Dzookeeper.ssl.trustStore.location=/var/lib/secret/truststore.jks  -Dzookeeper.ssl.trustStore.password=confluent
+```
+
+server.properties file:
+
+```
+zookeeper.connect=zookeeper:2182
+```
+
+to use the secure port, a use can use both (but I would certainly not recommended as it water down security)
+
+## Things pending..
+
+* The current zookeeper migration tool works based on JAAS files, there is currently no option to set authentication in a different way. There is an issue open with Apache Kafka (https://issues.apache.org/jira/browse/KAFKA-8843) to fix this, as well as the required overall KIP https://cwiki.apache.org/confluence/display/KAFKA/KIP-515%3A+Enable+ZK+client+to+use+the+new+TLS+supported+authentication, currently under discussion.
+
+* The https://cwiki.apache.org/confluence/display/KAFKA/KIP-515%3A+Enable+ZK+client+to+use+the+new+TLS+supported+authentication covers as well the challenge of configuring zookeeper TLS access, for the brokers, using environment variables. There is a change proposed to make things better.
+
+*NOTE*: This playbook utilised a custom made Apache Kafka docker image, build from a trunk snapshot the 22 of August 2019. Currently Apache Kafka 2.4 is still not released. Changing based images will be easy when an official confluent image is released.  
+
+## Reference
+
+* https://cwiki.apache.org/confluence/display/ZOOKEEPER/ZooKeeper+SSL+User+Guide
+* https://cwiki.apache.org/confluence/display/KAFKA/KIP-515%3A+Enable+ZK+client+to+use+the+new+TLS+supported+authentication
+* https://issues.apache.org/jira/browse/KAFKA-8843
+* https://github.com/apache/kafka/commit/d67495d6a7f4c5f7e8736a25d6a11a1c1bef8d87

--- a/apache-kafka-with-zk3.5-and-tls/docker-compose.yml
+++ b/apache-kafka-with-zk3.5-and-tls/docker-compose.yml
@@ -7,9 +7,6 @@ services:
     restart: on-failure
     environment:
       - SERVER_JVMFLAGS=-Dzookeeper.serverCnxnFactory=org.apache.zookeeper.server.NettyServerCnxnFactory
-    ports:
-      - 2181:2181
-      - 2182:2182
     volumes:
       - ./certs/zk-stores:/var/lib/secret
 
@@ -25,5 +22,4 @@ services:
     environment:
       - KAFKA_OPTS=-Dzookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty -Dzookeeper.client.secure=true -Dzookeeper.ssl.keyStore.location=/var/lib/secret/kafka.jks -Dzookeeper.ssl.keyStore.password=confluent -Dzookeeper.ssl.trustStore.location=/var/lib/secret/truststore.jks  -Dzookeeper.ssl.trustStore.password=confluent
     ports:
-      - 9092:9092
       - 29092:29092

--- a/apache-kafka-with-zk3.5-and-tls/docker-compose.yml
+++ b/apache-kafka-with-zk3.5-and-tls/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3'
+services:
+  zookeeper:
+    build: zookeeper/
+    container_name: zookeeper
+    hostname: zookeeper
+    restart: on-failure
+    environment:
+      - SERVER_JVMFLAGS=-Dzookeeper.serverCnxnFactory=org.apache.zookeeper.server.NettyServerCnxnFactory
+    ports:
+      - 2181:2181
+      - 2182:2182
+    volumes:
+      - ./certs/zk-stores:/var/lib/secret
+
+  kafka:
+    build: kafka/
+    container_name: kafka
+    hostname: kafka
+    depends_on:
+      - zookeeper
+    restart: on-failure
+    volumes:
+      - ./certs/kafka-stores:/var/lib/secret
+    environment:
+      - KAFKA_OPTS=-Dzookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty -Dzookeeper.client.secure=true -Dzookeeper.ssl.keyStore.location=/var/lib/secret/kafka.jks -Dzookeeper.ssl.keyStore.password=confluent -Dzookeeper.ssl.trustStore.location=/var/lib/secret/truststore.jks  -Dzookeeper.ssl.trustStore.password=confluent
+    ports:
+      - 9092:9092
+      - 29092:29092

--- a/apache-kafka-with-zk3.5-and-tls/kafka/Dockerfile
+++ b/apache-kafka-with-zk3.5-and-tls/kafka/Dockerfile
@@ -1,0 +1,13 @@
+FROM purbon/kafka
+MAINTAINER pere.urbon@gmail.com
+ENV container docker
+
+# 1. Install openjdk
+RUN yum install -y java-11-openjdk
+
+# 2. Configure Kafka
+COPY server.properties /etc/kafka/server.properties
+
+EXPOSE 9092
+
+CMD kafka-server-start.sh /etc/kafka/server.properties

--- a/apache-kafka-with-zk3.5-and-tls/kafka/server.properties
+++ b/apache-kafka-with-zk3.5-and-tls/kafka/server.properties
@@ -1,0 +1,181 @@
+  # Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# see kafka.server.KafkaConfig for additional details and defaults
+
+############################# Server Basics #############################
+
+# The id of the broker. This must be set to a unique integer for each broker.
+broker.id=0
+
+############################# Socket Server Settings #############################
+
+# The address the socket server listens on. It will get the value returned from
+# java.net.InetAddress.getCanonicalHostName() if not configured.
+#   FORMAT:
+#     listeners = listener_name://host_name:port
+#   EXAMPLE:
+#     listeners = PLAINTEXT://your.host.name:9092
+listeners=PLAINTEXT://kafka:9092,EXT_PLAINTEXT://localhost:29092
+
+# Hostname and port the broker will advertise to producers and consumers. If not set,
+# it uses the value for "listeners" if configured.  Otherwise, it will use the value
+# returned from java.net.InetAddress.getCanonicalHostName().
+advertised.listeners=PLAINTEXT://kafka:9092,EXT_PLAINTEXT://localhost:29092
+
+# Maps listener names to security protocols, the default is for them to be the same. See the config documentation for more details
+listener.security.protocol.map=PLAINTEXT:PLAINTEXT,EXT_PLAINTEXT:PLAINTEXT,SSL:SSL,SASL_PLAINTEXT:SASL_PLAINTEXT,SASL_SSL:SASL_SSL
+#security.inter.broker.protocol=SSL
+
+# The number of threads that the server uses for receiving requests from the network and sending responses to the network
+num.network.threads=3
+
+# The number of threads that the server uses for processing requests, which may include disk I/O
+num.io.threads=8
+
+# The send buffer (SO_SNDBUF) used by the socket server
+socket.send.buffer.bytes=102400
+
+# The receive buffer (SO_RCVBUF) used by the socket server
+socket.receive.buffer.bytes=102400
+
+# The maximum size of a request that the socket server will accept (protection against OOM)
+socket.request.max.bytes=104857600
+
+
+############################# Log Basics #############################
+
+# A comma separated list of directories under which to store log files
+log.dirs=/var/lib/kafka
+
+# The default number of log partitions per topic. More partitions allow greater
+# parallelism for consumption, but this will also result in more files across
+# the brokers.
+num.partitions=1
+
+# The number of threads per data directory to be used for log recovery at startup and flushing at shutdown.
+# This value is recommended to be increased for installations with data dirs located in RAID array.
+num.recovery.threads.per.data.dir=1
+
+############################# Internal Topic Settings  #############################
+# The replication factor for the group metadata internal topics "__consumer_offsets" and "__transaction_state"
+# For anything other than development testing, a value greater than 1 is recommended for to ensure availability such as 3.
+offsets.topic.replication.factor=1
+transaction.state.log.replication.factor=1
+transaction.state.log.min.isr=1
+
+############################# Log Flush Policy #############################
+
+# Messages are immediately written to the filesystem but by default we only fsync() to sync
+# the OS cache lazily. The following configurations control the flush of data to disk.
+# There are a few important trade-offs here:
+#    1. Durability: Unflushed data may be lost if you are not using replication.
+#    2. Latency: Very large flush intervals may lead to latency spikes when the flush does occur as there will be a lot of data to flush.
+#    3. Throughput: The flush is generally the most expensive operation, and a small flush interval may lead to excessive seeks.
+# The settings below allow one to configure the flush policy to flush data after a period of time or
+# every N messages (or both). This can be done globally and overridden on a per-topic basis.
+
+# The number of messages to accept before forcing a flush of data to disk
+#log.flush.interval.messages=10000
+
+# The maximum amount of time a message can sit in a log before we force a flush
+#log.flush.interval.ms=1000
+
+############################# Log Retention Policy #############################
+
+# The following configurations control the disposal of log segments. The policy can
+# be set to delete segments after a period of time, or after a given size has accumulated.
+# A segment will be deleted whenever *either* of these criteria are met. Deletion always happens
+# from the end of the log.
+
+# The minimum age of a log file to be eligible for deletion due to age
+log.retention.hours=168
+
+# A size-based retention policy for logs. Segments are pruned from the log unless the remaining
+# segments drop below log.retention.bytes. Functions independently of log.retention.hours.
+#log.retention.bytes=1073741824
+
+# The maximum size of a log segment file. When this size is reached a new log segment will be created.
+log.segment.bytes=1073741824
+
+# The interval at which log segments are checked to see if they can be deleted according
+# to the retention policies
+log.retention.check.interval.ms=300000
+
+############################# Zookeeper #############################
+
+# Zookeeper connection string (see zookeeper docs for details).
+# This is a comma separated host:port pairs, each corresponding to a zk
+# server. e.g. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002".
+# You can also append an optional chroot string to the urls to specify the
+# root directory for all kafka znodes.
+zookeeper.connect=zookeeper:2182
+
+# Timeout in ms for connecting to zookeeper
+zookeeper.connection.timeout.ms=6000
+
+##################### Confluent Metrics Reporter #######################
+# Confluent Control Center and Confluent Auto Data Balancer integration
+#
+# Uncomment the following lines to publish monitoring data for
+# Confluent Control Center and Confluent Auto Data Balancer
+# If you are using a dedicated metrics cluster, also adjust the settings
+# to point to your metrics kakfa cluster.
+#metric.reporters=io.confluent.metrics.reporter.ConfluentMetricsReporter
+#confluent.metrics.reporter.bootstrap.servers=localhost:9092
+#
+# Uncomment the following line if the metrics cluster has a single broker
+#confluent.metrics.reporter.topic.replicas=1
+
+##################### Confluent Proactive Support ######################
+# If set to true, and confluent-support-metrics package is installed
+# then the feature to collect and report support metrics
+# ("Metrics") is enabled.  If set to false, the feature is disabled.
+#
+#confluent.support.metrics.enable=false
+
+
+# The customer ID under which support metrics will be collected and
+# reported.
+#
+# When the customer ID is set to "anonymous" (the default), then only a
+# reduced set of metrics is being collected and reported.
+#
+# Confluent customers
+# -------------------
+# If you are a Confluent customer, then you should replace the default
+# value with your actual Confluent customer ID.  Doing so will ensure
+# that additional support metrics will be collected and reported.
+#
+#confluent.support.customer.id=anonymous
+
+############################# Group Coordinator Settings #############################
+
+# The following configuration specifies the time, in milliseconds, that the GroupCoordinator will delay the initial consumer rebalance.
+# The rebalance will be further delayed by the value of group.initial.rebalance.delay.ms as new members join the group, up to a maximum of max.poll.interval.ms.
+# The default value for this is 3 seconds.
+# We override this to 0 here as it makes for a better out-of-the-box experience for development and testing.
+# However, in production environments the default value of 3 seconds is more suitable as this will help to avoid unnecessary, and potentially expensive, rebalances during application startup.
+group.initial.rebalance.delay.ms=0
+
+
+# TLS Configuration
+#ssl.truststore.location=/var/lib/secret/truststore.jks
+#ssl.truststore.password=test1234
+#ssl.keystore.location=/var/lib/secret/server.keystore.jks
+#ssl.keystore.password=test1234
+#ssl.client.auth=required
+#authorizer.class.name=kafka.security.auth.SimpleAclAuthorizer
+#super.users=User:CN=kafka.confluent.local,L=London,O=Confluent,C=UK;User:CN=schema-registry.confluent.local,L=London,O=Confluent,C=UK

--- a/apache-kafka-with-zk3.5-and-tls/up
+++ b/apache-kafka-with-zk3.5-and-tls/up
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -e
+
+function gencert() {
+  if [ -a $1.jks ];
+  then
+    echo "The keystore $1.jks already exists";
+    exit;
+  fi
+
+  echo "Creating keystore $1.jks with a certificate and a key-pair for CN $1"
+  keytool -keystore $1.jks -alias $1 -validity $VALIDITY -genkey -storepass $PASSWORD -keypass $PASSWORD -dname "CN=$1,OU=kafka,O=confluent,L=MS,ST=Berlin,C=DE"
+  echo "Creating a Certificate-Signing-Request for the generated certificate"
+  keytool -keystore $1.jks -alias $1 -certreq -file cert-file -storepass $PASSWORD
+  echo "Signing the Certificate-Signing-Request and adding an additional DNS-entry for localhost"
+  openssl x509 -req -CA ca-cert -CAkey ca-key -in cert-file -out cert-signed -days $VALIDITY -CAcreateserial -passin pass:$PASSWORD -extensions SAN -extfile <(printf "\n[SAN]\nsubjectAltName=DNS:$1,DNS:localhost")
+  echo "Importing the root-certificate for the CA into the keystore $1.jks"
+  keytool -keystore $1.jks -alias CARoot -import -file ca-cert -storepass $PASSWORD -noprompt
+  echo "Importing the signed certificate for CN $1 into the keystore $1.jks"
+  keytool -keystore $1.jks -alias $1 -import -file cert-signed -storepass $PASSWORD
+  echo "Removing obsolet files..."
+  rm -v cert-file cert-signed
+}
+
+function gentruststore() {
+  if [ -a ca-cert ];
+  then
+    echo "The root-certificate for the CA already exists...";
+  else
+    echo "Creating a x509-certificate for the CA...";
+    openssl req -new -x509 -subj "/C=DE/ST=Berlin/L=MS/O=confluent/OU=kafka/CN=Root-CA" -keyout ca-key -out ca-cert -days $VALIDITY -passout pass:$PASSWORD
+  fi
+  #
+
+  if [ -a truststore.jks ];
+  then
+    echo "The keystore truststore.jks already exists!";
+  else
+    echo "Importing the root-certificate of the CA into truststore.jks..."
+    keytool -keystore truststore.jks -storepass $PASSWORD -alias CARoot -import -file ca-cert -noprompt
+  fi
+}
+
+rm -rf certs
+rm -rf tmp-dir
+mkdir tmp-dir
+mkdir -p certs/kafka-stores
+mkdir -p certs/zk-stores
+
+VALIDITY=365
+PASSWORD=confluent
+
+
+(cd tmp-dir; gentruststore)
+
+hosts=( "zookeeper" "client" "kafka")
+
+for host in "${hosts[@]}"
+do
+  (cd tmp-dir; gencert $host )
+done
+
+cp tmp-dir/truststore.jks certs/kafka-stores
+cp tmp-dir/truststore.jks certs/zk-stores
+cp tmp-dir/zookeeper.jks certs/zk-stores
+cp tmp-dir/kafka.jks certs/kafka-stores
+
+# Starting docker-compose services
+docker-compose up -d --build
+
+echo "Example configuration to access kafka:"
+echo "-> docker-compose exec kafka kafka-topics.sh --bootstrap-server kafka:9092 --create --topic foo --partitions 1 --replication-factor 1"
+echo "-> docker-compose exec kafka kafka-console-producer.sh --broker-list kafka:9092 --topic foo"
+echo "-> docker-compose exec kafka kafka-console-consumer.sh --bootstrap-server kafka:9092  --topic foo --from-beginning"

--- a/apache-kafka-with-zk3.5-and-tls/zookeeper/Dockerfile
+++ b/apache-kafka-with-zk3.5-and-tls/zookeeper/Dockerfile
@@ -1,0 +1,19 @@
+FROM purbon/zookeeper:3.5.5
+MAINTAINER pere.urbon@gmail.com
+ENV container docker
+
+# 2. Install zookeeper and kafka
+RUN yum install -y java-11-openjdk
+
+
+# 3. Configure zookeeper
+COPY zoo.cfg "${ZK_HOME}/conf/zoo.cfg"
+
+# 4. Add extra utility scripts
+
+ENV PATH="/opt/tlsZkCli.sh:${PATH}"
+COPY tlsZkCli.sh /opt/tlsZkCli.sh
+
+EXPOSE 2182
+
+CMD zkServer.sh start-foreground

--- a/apache-kafka-with-zk3.5-and-tls/zookeeper/tlsZkCli.sh
+++ b/apache-kafka-with-zk3.5-and-tls/zookeeper/tlsZkCli.sh
@@ -1,0 +1,9 @@
+##!/usr/bin/env bash
+
+export CLIENT_JVMFLAGS="-Dzookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty  -Dzookeeper.client.secure=true
+  -Dzookeeper.ssl.keyStore.location=/var/lib/secret/zookeeper.jks
+  -Dzookeeper.ssl.keyStore.password=confluent
+  -Dzookeeper.ssl.trustStore.location=/var/lib/secret/truststore.jks
+  -Dzookeeper.ssl.trustStore.password=confluent"
+
+zkCli.sh -server $1

--- a/apache-kafka-with-zk3.5-and-tls/zookeeper/zoo.cfg
+++ b/apache-kafka-with-zk3.5-and-tls/zookeeper/zoo.cfg
@@ -33,4 +33,7 @@ ssl.trustStore.location=/var/lib/secret/truststore.jks
 ssl.trustStore.password=confluent
 ssl.keyStore.location=/var/lib/secret/zookeeper.jks
 ssl.keyStore.password=confluent
+# This option is commented out only as an example of what is possible for the
+# SSL authentication. In a production environment this should be set as
+# here, with ssl.clientAuth=need
 #ssl.clientAuth=need

--- a/apache-kafka-with-zk3.5-and-tls/zookeeper/zoo.cfg
+++ b/apache-kafka-with-zk3.5-and-tls/zookeeper/zoo.cfg
@@ -1,0 +1,36 @@
+# The number of milliseconds of each tick
+tickTime=2000
+# The number of ticks that the initial
+# synchronization phase can take
+initLimit=10
+# The number of ticks that can pass between
+# sending a request and getting an acknowledgement
+syncLimit=5
+# the directory where the snapshot is stored.
+# do not use /tmp for storage, /tmp here is just
+# example sakes.
+dataDir=/tmp/zookeeper
+# the port at which the clients will connect
+#clientPort=2181
+secureClientPort=2182
+# the maximum number of client connections.
+# increase this if you need to handle more clients
+#maxClientCnxns=60
+#
+# Be sure to read the maintenance section of the
+# administrator guide before turning on autopurge.
+#
+# http://zookeeper.apache.org/doc/current/zookeeperAdmin.html#sc_maintenance
+#
+# The number of snapshots to retain in dataDir
+#autopurge.snapRetainCount=3
+# Purge task interval in hours
+# Set to "0" to disable auto purge feature
+#autopurge.purgeInterval=1
+
+authProvider.1=org.apache.zookeeper.server.auth.X509AuthenticationProvider
+ssl.trustStore.location=/var/lib/secret/truststore.jks
+ssl.trustStore.password=confluent
+ssl.keyStore.location=/var/lib/secret/zookeeper.jks
+ssl.keyStore.password=confluent
+#ssl.clientAuth=need


### PR DESCRIPTION
This playbook show the current (as of August 2019) necessary steps to enable a secured TLS connection between an Apache Kafka broker and his corresponding
Apache Zookeeper counter part.

As of today, this only covers using Zookeeper 3.5.5 with the upcoming Apache Kafka 2.4 version. Using it in earlier versions is not properly tested.

*NOTE*: This playbook utilised a custom made Apache Kafka docker image, build from a trunk snapshot the 22 of August 2019. Currently Apache Kafka 2.4 is still not released. Changing based images will be easy when an official confluent image is released.