### PR TITLE
Use Bash in shebang

### DIFF
--- a/rbac/up
+++ b/rbac/up
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 ## start docker-compose up to and including kafka
 docker-compose up -d kafka


### PR DESCRIPTION
use bash for the script
when /bin/sh is used source didn't work on zsh