### PR TITLE
Upgraded to 6.0 and added metrics reporters

### DIFF
--- a/tls/kafka/Dockerfile
+++ b/tls/kafka/Dockerfile
@@ -3,15 +3,13 @@ MAINTAINER d.gasparina@gmail.com
 ENV container docker
 
 # 1. Adding Confluent repository
-RUN rpm --import https://packages.confluent.io/rpm/5.4/archive.key
+RUN rpm --import https://packages.confluent.io/rpm/6.0/archive.key
 COPY confluent.repo /etc/yum.repos.d/confluent.repo
 RUN yum clean all
 
 # 2. Install zookeeper and kafka
-RUN yum install -y java-1.8.0-openjdk
-RUN yum install -y confluent-platform-2.12
-#schema-registry package is rquiterd to run kafka-avro-console-producer
-RUN yum install -y confluent-schema-registry
+RUN yum install -y java-11-openjdk
+RUN yum install -y confluent-server
 
 # 3. Configure Kafka 
 COPY server.properties /etc/kafka/server.properties

--- a/tls/kafka/confluent.repo
+++ b/tls/kafka/confluent.repo
@@ -1,13 +1,13 @@
 [Confluent.dist]
 name=Confluent repository (dist)
-baseurl=https://packages.confluent.io/rpm/5.4/7
+baseurl=https://packages.confluent.io/rpm/6.0/7
 gpgcheck=1
-gpgkey=https://packages.confluent.io/rpm/5.4/archive.key
+gpgkey=https://packages.confluent.io/rpm/6.0/archive.key
 enabled=1
 
 [Confluent]
 name=Confluent repository
-baseurl=https://packages.confluent.io/rpm/5.4
+baseurl=https://packages.confluent.io/rpm/6.0
 gpgcheck=1
-gpgkey=https://packages.confluent.io/rpm/5.4/archive.key
+gpgkey=https://packages.confluent.io/rpm/6.0/archive.key
 enabled=1

--- a/tls/kafka/server.properties
+++ b/tls/kafka/server.properties
@@ -15,3 +15,16 @@ ssl.keystore.password=test1234
 ssl.client.auth=required
 authorizer.class.name=kafka.security.auth.SimpleAclAuthorizer
 super.users=User:CN=kafka.confluent.local,L=London,O=Confluent,C=UK;User:CN=schema-registry.confluent.local,L=London,O=Confluent,C=UK
+
+# Metrics-reporters
+metric.reporters=io.confluent.metrics.reporter.ConfluentMetricsReporter
+confluent.metrics.reporter.bootstrap.servers=kafka.confluent.local:9093
+confluent.metrics.reporter.security.protocol=SSL
+confluent.metrics.reporter.ssl.truststore.location=/var/lib/secret/truststore.jks
+confluent.metrics.reporter.ssl.truststore.password=test1234
+confluent.metrics.reporter.ssl.keystore.location=/var/lib/secret/server.keystore.jks
+confluent.metrics.reporter.ssl.keystore.password=test1234
+confluent.metrics.reporter.ssl.key.password=test1234
+
+confluent.metrics.reporter.topic.replicas=1
+

--- a/tls/schema-registry/Dockerfile
+++ b/tls/schema-registry/Dockerfile
@@ -3,12 +3,12 @@ MAINTAINER d.gasparina@gmail.com
 ENV container docker
 
 # 1. Adding Confluent repository
-RUN rpm --import https://packages.confluent.io/rpm/5.4/archive.key
+RUN rpm --import https://packages.confluent.io/rpm/6.0/archive.key
 COPY confluent.repo /etc/yum.repos.d/confluent.repo
 RUN yum clean all
 
 # 2. Install zookeeper and kafka
-RUN yum install -y java-1.8.0-openjdk
+RUN yum install -y java-11-openjdk
 RUN yum install -y confluent-schema-registry confluent-security
 
 # 3. Configure Kafka 

--- a/tls/schema-registry/confluent.repo
+++ b/tls/schema-registry/confluent.repo
@@ -1,13 +1,13 @@
 [Confluent.dist]
 name=Confluent repository (dist)
-baseurl=https://packages.confluent.io/rpm/5.4/7
+baseurl=https://packages.confluent.io/rpm/6.0/7
 gpgcheck=1
-gpgkey=https://packages.confluent.io/rpm/5.4/archive.key
+gpgkey=https://packages.confluent.io/rpm/6.0/archive.key
 enabled=1
 
 [Confluent]
 name=Confluent repository
-baseurl=https://packages.confluent.io/rpm/5.4
+baseurl=https://packages.confluent.io/rpm/6.0
 gpgcheck=1
-gpgkey=https://packages.confluent.io/rpm/5.4/archive.key
+gpgkey=https://packages.confluent.io/rpm/6.0/archive.key
 enabled=1

--- a/tls/zookeeper/Dockerfile
+++ b/tls/zookeeper/Dockerfile
@@ -3,13 +3,13 @@ MAINTAINER d.gasparina@gmail.com
 ENV container docker
 
 # 1. Adding Confluent repository
-RUN rpm --import https://packages.confluent.io/rpm/5.4/archive.key
+RUN rpm --import https://packages.confluent.io/rpm/6.0/archive.key
 COPY confluent.repo /etc/yum.repos.d/confluent.repo
 RUN yum clean all
 
 # 2. Install zookeeper and kafka
-RUN yum install -y java-1.8.0-openjdk
-RUN yum install -y confluent-platform-2.12
+RUN yum install -y java-11-openjdk
+RUN yum install -y confluent-platform
 
 # 3. Configure zookeeper
 COPY zookeeper.properties /etc/kafka/zookeeper.properties

--- a/tls/zookeeper/confluent.repo
+++ b/tls/zookeeper/confluent.repo
@@ -1,13 +1,13 @@
 [Confluent.dist]
 name=Confluent repository (dist)
-baseurl=https://packages.confluent.io/rpm/5.4/7
+baseurl=https://packages.confluent.io/rpm/6.0/7
 gpgcheck=1
-gpgkey=https://packages.confluent.io/rpm/5.4/archive.key
+gpgkey=https://packages.confluent.io/rpm/6.0/archive.key
 enabled=1
 
 [Confluent]
 name=Confluent repository
-baseurl=https://packages.confluent.io/rpm/5.4
+baseurl=https://packages.confluent.io/rpm/6.0
 gpgcheck=1
-gpgkey=https://packages.confluent.io/rpm/5.4/archive.key
+gpgkey=https://packages.confluent.io/rpm/6.0/archive.key
 enabled=1


### PR DESCRIPTION
Example of how to authenticate the metrics reporter using TLS.

Missing: example on how to use schema registry as well.